### PR TITLE
Change some parameters from `&Path` to `AsRef<OsStr>`

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -107,7 +107,7 @@ impl Device {
     }
 
     /// Returns the parent of the device with the matching subsystem and devtype if any.
-    pub fn parent_with_subsystem(&self, subsystem: &Path) -> Result<Option<Self>> {
+    pub fn parent_with_subsystem<T: AsRef<OsStr>>(&self, subsystem: T) -> Result<Option<Self>> {
         let subsystem = util::os_str_to_cstring(subsystem)?;
         let ptr = unsafe {
             ffi::udev_device_get_parent_with_subsystem_devtype(
@@ -125,10 +125,10 @@ impl Device {
     }
 
     /// Returns the parent of the device with the matching subsystem and devtype if any.
-    pub fn parent_with_subsystem_devtype(
+    pub fn parent_with_subsystem_devtype<T: AsRef<OsStr>, U: AsRef<OsStr>>(
         &self,
-        subsystem: &Path,
-        devtype: &Path,
+        subsystem: T,
+        devtype: U
     ) -> Result<Option<Self>> {
         let subsystem = util::os_str_to_cstring(subsystem)?;
         let devtype = util::os_str_to_cstring(devtype)?;

--- a/src/enumerator.rs
+++ b/src/enumerator.rs
@@ -141,7 +141,7 @@ impl Enumerator {
     }
 
     /// Includes the device with the given syspath.
-    pub fn add_syspath(&mut self, syspath: &Path) -> Result<()> {
+    pub fn add_syspath<T: AsRef<OsStr>>(&mut self, syspath: T) -> Result<()> {
         let syspath = util::os_str_to_cstring(syspath)?;
 
         util::errno_to_result(unsafe {


### PR DESCRIPTION
There were a few methods in the API that took `&Path` parameters which makes
it awkward to pass in `&'static str` and other such things. There were other
existing methods that used `AsRef<OsStr>` so I changed the rest to match.

Additionally rustc now produces a deprecation warning for `try!` so I replaced
all usage of `try!` with the `?` operator.