### PR TITLE
Fix monitor builder initialisation

### DIFF
--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -31,7 +31,7 @@ as_ffi!(Builder, monitor, ffi::udev_monitor);
 impl Builder {
     /// Creates a new `Monitor`.
     pub fn new() -> Result<Self> {
-        let name = b"udev".as_ptr() as *const i8;
+        let name = b"udev\0".as_ptr() as *const i8;
 
         let ptr = try_alloc!(unsafe { ffi::udev_monitor_new_from_netlink(ptr::null_mut(), name) });
 


### PR DESCRIPTION
A byte string literal isn't nul terminated unless explicitly done so;
Hence they can't be used as C strings without adding an explicit nul
byte.

Signed-off-by: Sjoerd Simons <sjoerd.simons@collabora.co.uk>