### PR TITLE
Correct lifetime of Attribute::{name, value} getters

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -367,12 +367,12 @@ pub struct Attribute<'a> {
 
 impl<'a> Attribute<'a> {
     /// Returns the attribute name.
-    pub fn name(&self) -> &OsStr {
+    pub fn name(&self) -> &'a OsStr {
         self.name
     }
 
     /// Returns the attribute value.
-    pub fn value(&self) -> Option<&OsStr> {
+    pub fn value(&self) -> Option<&'a OsStr> {
         self.device.attribute_value(self.name)
     }
 }


### PR DESCRIPTION
These getter functions were previously declared as
```rust
impl<'a> Attribute<'a> {
  pub fn name(&self) -> &OsStr {...}
  pub fn value(&self) -> Option<&OsStr> {...}
},
```
but this limits the lifetime of the strings returned by them to the lifetime of the `Attribute`, which is typically a short-lived reference.

They should instead be:
```rust
impl<'a> Attribute<'a> {
  pub fn name(&self) -> &'a OsStr {...}
  pub fn value(&self) -> Option<&'a OsStr> {...}
}.
```
`&'a` represents the lifetime of the device so this is correct. In fact, the `name` field in `Attribute` already has `&'a` lifetime.

Ran into this when filtering attributes like this:
```rust
dev.attributes()
.find(|a| predicate(a.name()))
.and_then(|a| a.value())
```
```
   | .and_then(|a| a.value())
   |               -^^^^^^^^
   |               |
   |               returns a value referencing data owned by the current function
   |               `a` is borrowed here
```