### PR TITLE
Fix "hack" from #14 by using a real `udev` context object

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ extern crate mio;
 pub use device::{Attribute, Attributes, Device, Properties, Property};
 pub use enumerator::{Devices, Enumerator};
 pub use monitor::{Builder as MonitorBuilder, Event, EventType, Socket as MonitorSocket};
-pub(crate) use udev::Udev;
+pub use udev::Udev;
 
 macro_rules! try_alloc {
     ($exp:expr) => {{
@@ -32,10 +32,30 @@ pub trait AsRaw<T: 'static> {
     ///
     /// The reference count will not be increased.
     fn as_raw(&self) -> *mut T;
+
     /// Convert the object into the underlying pointer.
     ///
     /// You are responsible for freeing the object.
     fn into_raw(self) -> *mut T;
+}
+
+/// Receive the underlying raw pointer for types with an associated `udev` struct which must
+/// outlive them.
+pub trait AsRawWithContext<T: 'static> {
+    /// Get a reference of the underlying struct.
+    ///
+    /// The reference count will not be increased.
+    fn as_raw(&self) -> *mut T;
+
+    /// The `udev` context with which this struct was created.  This must live at least as long as
+    /// the struct itself or undefined behavior will result.
+    fn udev(&self) -> &Udev;
+
+    /// Convert the object into the raw `udev` pointer and the underlying pointer for this object.
+    ///
+    /// You are responsible for freeing both.  You're also responsible for ensuring that the `udev`
+    /// pointer is not freed until after this object's pointer is freed.
+    fn into_raw_with_context(self) -> (*mut ffi::udev, *mut T);
 }
 
 /// Convert from a raw pointer
@@ -44,29 +64,60 @@ pub trait FromRaw<T: 'static> {
     ///
     /// The reference count will not be increased, be sure not to free this pointer.
     ///
-    /// ## Unsafety
+    /// ## Safety
     ///
     /// The pointer has to be a valid reference to the expected underlying udev-struct or undefined
     /// behaviour might occur.
     unsafe fn from_raw(ptr: *mut T) -> Self;
 }
 
+/// Convert from a raw pointer for types which must be associated with a `Udev` context object.
+pub trait FromRawWithContext<T: 'static> {
+    /// Create an object from a given raw pointer and `udev` context pointer.
+    ///
+    /// The reference count will not be increased, be sure not to free this pointer.
+    ///
+    /// ## Safety
+    ///
+    /// The `udev` pointer must correspond to the `udev` pointer used when `ptr` was created.  If
+    /// not memory corruption and undefined behavior will result.
+    ///
+    /// Both the `udev` and `ptr` pointers must be a valid reference to the expected underlying udev-struct or undefined
+    /// behaviour might occur.  Do NOT attempt to free either pointer; `udev_unref` and the
+    /// corresponding `*_unref` function for `ptr` will be called automatically when this type is
+    /// dropped.
+    unsafe fn from_raw_with_context(udev: *mut ffi::udev, ptr: *mut T) -> Self;
+}
+
 /// Convert from a raw pointer and the matching context
 macro_rules! as_ffi {
-    ($struct_:ident, $field:ident, $type_:ty) => {
-        as_raw!($struct_, $field, $type_);
+    ($struct_:ident, $field:ident, $type_:ty, $ref:path) => {
+        as_raw!($struct_, $field, $type_, $ref);
         from_raw!($struct_, $field, $type_);
     };
 }
 
+macro_rules! as_ffi_with_context {
+    ($struct_:ident, $field:ident, $type_:ty, $ref:path) => {
+        as_raw_with_context!($struct_, $field, $type_, $ref);
+        from_raw_with_context!($struct_, $field, $type_);
+    };
+}
+
 macro_rules! as_raw {
-    ($struct_:ident, $field:ident, $type_:ty) => {
+    ($struct_:ident, $field:ident, $type_:ty, $ref:path) => {
         impl $crate::AsRaw<$type_> for $struct_ {
             fn as_raw(&self) -> *mut $type_ {
                 self.$field
             }
 
             fn into_raw(self) -> *mut $type_ {
+                // Note that all `AsRaw` implementations also implement `Drop` which calls the
+                // `_unref` function that correponds to $type_.  We can't prevent this from
+                // happening, so we have to add a reference here to ensure the returned pointer
+                // remains allocated for the caller.
+                unsafe { $ref(self.$field) };
+
                 self.$field
             }
         }
@@ -78,6 +129,55 @@ macro_rules! from_raw {
         impl $crate::FromRaw<$type_> for $struct_ {
             unsafe fn from_raw(t: *mut $type_) -> Self {
                 Self { $field: t }
+            }
+        }
+    };
+}
+
+macro_rules! as_raw_with_context {
+    ($struct_:ident, $field:ident, $type_:ty, $ref:path) => {
+        impl $crate::AsRawWithContext<$type_> for $struct_ {
+            fn as_raw(&self) -> *mut $type_ {
+                self.$field
+            }
+
+            fn udev(&self) -> &Udev {
+                &self.udev
+            }
+
+            fn into_raw_with_context(self) -> (*mut ffi::udev, *mut $type_) {
+                // We can't call `self.udev.into_raw()` here, because that will consume
+                // `self.udev`, which is not possible because every type that implements
+                // `AsRawWithContext` also implements `Drop`.  Of course we know that it would be
+                // safe here to just skip the `drop()` on `Udev` and "leak" the `udev` pointer back
+                // to the caller, but the Rust compiler doesn't know that.
+                //
+                // So instead we have to add a new reference to the `udev` pointer before we return
+                // it, because as soon as we leave the scope of this function the `Udev` struct
+                // will be dropped which will call `udev_unref` on it.  If there's only once
+                // reference left that will free the pointer and we'll end up returning a dangling
+                // pointer to the caller.
+                //
+                // For much the same reason, we do the same with the pointer of type $type
+                let udev = self.udev.as_raw();
+                unsafe { ffi::udev_ref(udev) };
+
+                unsafe { $ref(self.$field) };
+
+                (udev, self.$field)
+            }
+        }
+    };
+}
+
+macro_rules! from_raw_with_context {
+    ($struct_:ident, $field:ident, $type_:ty) => {
+        impl $crate::FromRawWithContext<$type_> for $struct_ {
+            unsafe fn from_raw_with_context(udev: *mut ffi::udev, t: *mut $type_) -> Self {
+                Self {
+                    udev: Udev::from_raw(udev),
+                    $field: t,
+                }
             }
         }
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ extern crate mio;
 pub use device::{Attribute, Attributes, Device, Properties, Property};
 pub use enumerator::{Devices, Enumerator};
 pub use monitor::{Builder as MonitorBuilder, Event, EventType, Socket as MonitorSocket};
+pub(crate) use udev::Udev;
 
 macro_rules! try_alloc {
     ($exp:expr) => {{
@@ -53,6 +54,13 @@ pub trait FromRaw<T: 'static> {
 /// Convert from a raw pointer and the matching context
 macro_rules! as_ffi {
     ($struct_:ident, $field:ident, $type_:ty) => {
+        as_raw!($struct_, $field, $type_);
+        from_raw!($struct_, $field, $type_);
+    };
+}
+
+macro_rules! as_raw {
+    ($struct_:ident, $field:ident, $type_:ty) => {
         impl $crate::AsRaw<$type_> for $struct_ {
             fn as_raw(&self) -> *mut $type_ {
                 self.$field
@@ -62,7 +70,11 @@ macro_rules! as_ffi {
                 self.$field
             }
         }
+    };
+}
 
+macro_rules! from_raw {
+    ($struct_:ident, $field:ident, $type_:ty) => {
         impl $crate::FromRaw<$type_> for $struct_ {
             unsafe fn from_raw(t: *mut $type_) -> Self {
                 Self { $field: t }
@@ -74,4 +86,5 @@ macro_rules! as_ffi {
 mod device;
 mod enumerator;
 mod monitor;
+mod udev;
 mod util;

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -12,7 +12,7 @@ use mio::{event::Evented, unix::EventedFd, Poll, PollOpt, Ready, Token};
 use Udev;
 use {ffi, util};
 
-use {AsRaw, Device};
+use {AsRaw, AsRawWithContext, Device, FromRaw};
 
 /// Monitors for device events.
 ///
@@ -41,7 +41,7 @@ impl Drop for Builder {
     }
 }
 
-as_raw!(Builder, monitor, ffi::udev_monitor);
+as_ffi_with_context!(Builder, monitor, ffi::udev_monitor, ffi::udev_monitor_ref);
 
 impl Builder {
     /// Creates a new `Monitor`.

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -1,0 +1,64 @@
+use std::io::Result;
+
+use ffi;
+
+use FromRaw;
+
+/// Rust wrapper for the `udev` struct which represents an opaque libudev context
+///
+/// Most other `libudev` calls take a `struct udev*` argument, although whether or not this
+/// argument is actually used depends on the version of libudev.  In more recent versions the
+/// context is ignored, therefore it sometimes works to pass a NULL or a invalid pointer for
+/// `udev`.  However older versions, specifically 215 which shipped with Debian 8, expect this to
+/// be a valid `udev` struct.  Thus it is not optional.
+///
+/// `udev` is a ref-counted struct, with references added and removed with `udev_ref` and
+/// `udef_unref` respectively.  This Rust wrapper takes advantage of that ref counting to implement
+/// `Clone` and `Drop`, so callers need not worry about any C-specific resource management.
+pub(crate) struct Udev {
+    udev: *mut ffi::udev,
+}
+
+impl Clone for Udev {
+    fn clone(&self) -> Self {
+        unsafe { Self::from_raw(ffi::udev_ref(self.udev)) }
+    }
+}
+
+impl Drop for Udev {
+    fn drop(&mut self) {
+        unsafe { ffi::udev_unref(self.udev) };
+    }
+}
+
+as_ffi!(Udev, udev, ffi::udev);
+
+impl Udev {
+    /// Creates a new Udev context.
+    pub fn new() -> Result<Self> {
+        let ptr = try_alloc!(unsafe { ffi::udev_new() });
+        Ok(unsafe { Self::from_raw(ptr) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use AsRaw;
+
+    #[test]
+    fn clone_drop() {
+        // Exercise clone/drop.  We won't be able to catch a bug here that leaks memory, but a
+        // crash due to the ref count getting out of whack would show up here.
+        let mut udev = Udev::new().unwrap();
+
+        for _ in 0..1000 {
+            let clone = udev.clone();
+
+            assert_eq!(udev.as_raw(), clone.as_raw());
+
+            // This will `drop()` what's in `udev`, and transfer ownership from `clone` to `udev`
+            udev = clone;
+        }
+    }
+}


### PR DESCRIPTION
Summary
---
This introduces an internal (`pub(crate)`) struct `Udev`, which wraps
the libudev `struct udev*` in almost the same way that `Enumerator`
wraps `udev_enumerate*`.  This is then used by `Enumerator::new`,
`Builder::new`, and `Device::from_syspath` to ensure enumerators,
monitors, and devices always have a valid `udev` context.  Any `Device`
instances discovered via `Enumerator` or `Builder` will share the same
`Udev` instance as the `Enumerator` or `Builder` they came from, so the
overhead associated with this change should be minimal.

Tests
---
The existing unit tests did not reproduce this problem when running in
Debian 8 "jessie".  I can't explain why, although I assume that the fact
that the enumerate test limits the results to "hidraw" subsystem may be
a factor.  I added another test to enumerate all devices.

Note that the `list_devices` example program _did_ segfault on Debian
"jessie".

I've also added a test for the new `Udev` struct which exercises the
`clone`/`drop` implementation by making sure the same instance is used
each time.  I ran these tests under `valgrind` to confirm there were no
memory leaks.

Compatibility
---
I've tried to keep the compatibility issues to a minimum, however one
breaking change was unavoidable: `Enumerator`, `Builder`, and `Device`
no longer implement `FromRaw`, because their structs now maintain not
only the `struct udev_enumerate*` but also the Rust `Udev` struct which
contains the context with which that `Enumerator`/`Builder`/`Device` was
created.  This is required to keep the `struct udev*` instance alive for
the duration of other structs' lifetimes.

Ideally the `FromRaw` trait would have been crate-internal anyway, but
since it wasn't before this change I'm not attempting to change its
visibility now.  However any code that depends on `Enumerator`,
`Builder`, or `Device` implementing `FromRaw` will break with this
change, therefore this probably needs to be published to crates.io with
an incremented version number.

Closes #18