### PR TITLE
The Attributes iterator now gets the values.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use libc::{c_char, dev_t};
 
-use list::{EntryList, Entry};
+use list::{Entry, EntryList};
 use Udev;
 use {ffi, util};
 
@@ -361,12 +361,10 @@ impl<'a> Iterator for Attributes<'a> {
     // the values being empty. To get the value, each has to be queried.
     fn next(&mut self) -> Option<Entry<'a>> {
         match self.entries.next() {
-            Some(Entry { name, value: _ }) => {
-                Some( Entry {
-                    name,
-                    value: self.device.attribute_value(name),
-                })
-            },
+            Some(Entry { name, value: _ }) => Some(Entry {
+                name,
+                value: self.device.attribute_value(name),
+            }),
             None => None,
         }
     }
@@ -375,4 +373,3 @@ impl<'a> Iterator for Attributes<'a> {
         (0, None)
     }
 }
-

--- a/src/device.rs
+++ b/src/device.rs
@@ -9,7 +9,7 @@ use std::str::FromStr;
 
 use libc::{c_char, dev_t};
 
-use list::EntryList;
+use list::{EntryList, Entry};
 use Udev;
 use {ffi, util};
 
@@ -63,7 +63,10 @@ as_ffi_with_context!(Device, device, ffi::udev_device, ffi::udev_device_ref);
 pub type Properties<'a> = EntryList<'a, Device>;
 
 /// A convenience alias for a list of attributes, bound to a device.
-pub type Attributes<'a> = EntryList<'a, Device>;
+pub struct Attributes<'a> {
+    entries: EntryList<'a, Device>,
+    device: &'a Device,
+}
 
 impl Device {
     /// Creates a device for a given syspath.
@@ -337,8 +340,11 @@ impl Device {
     /// ```
     pub fn attributes(&self) -> Attributes {
         Attributes {
-            entry: unsafe { ffi::udev_device_get_sysattr_list_entry(self.device) },
-            phantom: PhantomData,
+            entries: EntryList {
+                entry: unsafe { ffi::udev_device_get_sysattr_list_entry(self.device) },
+                phantom: PhantomData,
+            },
+            device: self,
         }
     }
 
@@ -347,3 +353,26 @@ impl Device {
         unsafe { util::ptr_to_os_str(ffi::udev_device_get_action(self.device)) }
     }
 }
+
+impl<'a> Iterator for Attributes<'a> {
+    type Item = Entry<'a>;
+
+    // The list of sysattr entries only contains the attribute names, with
+    // the values being empty. To get the value, each has to be queried.
+    fn next(&mut self) -> Option<Entry<'a>> {
+        match self.entries.next() {
+            Some(Entry { name, value: _ }) => {
+                Some( Entry {
+                    name,
+                    value: self.device.attribute_value(name),
+                })
+            },
+            None => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (0, None)
+    }
+}
+


### PR DESCRIPTION
This fixes the `Attributes` iterator to fetch the value for each entry. The underlying _libudev_ list only contains the attributes list with blanks for each value. See #30