### PR TITLE
Mark `ptr_to_os_str` as unsafe, and implement with `CStr::from_ptr`

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -153,7 +153,7 @@ impl Device {
     /// The path is an absolute path and starts with the device directory. For example, the device
     /// node for `tty0` could be `/dev/tty0`.
     pub fn devnode(&self) -> Option<&Path> {
-        util::ptr_to_os_str(unsafe { ffi::udev_device_get_devnode(self.device) })
+        unsafe { util::ptr_to_os_str(ffi::udev_device_get_devnode(self.device)) }
             .map(|path| Path::new(path))
     }
 
@@ -220,7 +220,7 @@ impl Device {
     /// The subsystem name is a string that indicates which kernel subsystem the device belongs to.
     /// Examples of subsystem names are `tty`, `vtconsole`, `block`, `scsi`, and `net`.
     pub fn subsystem(&self) -> Option<&OsStr> {
-        util::ptr_to_os_str(unsafe { ffi::udev_device_get_subsystem(self.device) })
+        unsafe { util::ptr_to_os_str(ffi::udev_device_get_subsystem(self.device)) }
     }
 
     /// Returns the kernel device name for the device.
@@ -255,12 +255,12 @@ impl Device {
 
     /// Returns the devtype name of the device.
     pub fn devtype(&self) -> Option<&OsStr> {
-        util::ptr_to_os_str(unsafe { ffi::udev_device_get_devtype(self.device) })
+        unsafe { util::ptr_to_os_str(ffi::udev_device_get_devtype(self.device)) }
     }
 
     /// Returns the name of the kernel driver attached to the device.
     pub fn driver(&self) -> Option<&OsStr> {
-        util::ptr_to_os_str(unsafe { ffi::udev_device_get_driver(self.device) })
+        unsafe { util::ptr_to_os_str(ffi::udev_device_get_driver(self.device)) }
     }
 
     /// Retreives the value of a device property.
@@ -270,9 +270,12 @@ impl Device {
             Err(_) => return None,
         };
 
-        util::ptr_to_os_str(unsafe {
-            ffi::udev_device_get_property_value(self.device, prop.as_ptr())
-        })
+        unsafe {
+            util::ptr_to_os_str(ffi::udev_device_get_property_value(
+                self.device,
+                prop.as_ptr(),
+            ))
+        }
     }
 
     /// Retreives the value of a device attribute.
@@ -282,9 +285,12 @@ impl Device {
             Err(_) => return None,
         };
 
-        util::ptr_to_os_str(unsafe {
-            ffi::udev_device_get_sysattr_value(self.device, attr.as_ptr())
-        })
+        unsafe {
+            util::ptr_to_os_str(ffi::udev_device_get_sysattr_value(
+                self.device,
+                attr.as_ptr(),
+            ))
+        }
     }
 
     /// Sets the value of a device attribute.

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,24 +1,20 @@
-use std::ffi::{CString, OsStr};
+use std::ffi::{CStr, CString, OsStr};
 use std::io::Result;
-use std::slice;
 
 use libc::{c_char, c_int};
 
 use std::os::unix::prelude::*;
 
-pub fn ptr_to_os_str<'a>(ptr: *const c_char) -> Option<&'a OsStr> {
+pub unsafe fn ptr_to_os_str<'a>(ptr: *const c_char) -> Option<&'a OsStr> {
     if ptr.is_null() {
         return None;
     }
 
-    Some(unsafe { ptr_to_os_str_unchecked(ptr) })
+    Some(ptr_to_os_str_unchecked(ptr))
 }
 
 pub unsafe fn ptr_to_os_str_unchecked<'a>(ptr: *const c_char) -> &'a OsStr {
-    OsStr::from_bytes(slice::from_raw_parts(
-        ptr as *const u8,
-        libc::strlen(ptr) as usize,
-    ))
+    OsStr::from_bytes(CStr::from_ptr(ptr).to_bytes())
 }
 
 pub fn os_str_to_cstring<T: AsRef<OsStr>>(s: T) -> Result<CString> {


### PR DESCRIPTION
Dereferencing raw pointers can be unsound for reasons other than having a null pointer, so this function should be marked `unsafe`.

Using `CStr::from_ptr` here is a bit shorter, and should have the same result, so it seems slightly better than calling `strlen` and `from_raw_parts`.