### PR TITLE
Add SocketIter and remove socket.clone()

### DIFF
--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -48,7 +48,7 @@ mod poll {
         ) -> c_int;
     }
 
-    pub fn poll(mut socket: udev::MonitorSocket) -> io::Result<()> {
+    pub fn poll(socket: udev::MonitorSocket) -> io::Result<()> {
         println!("Use syspoll");
         let mut fds = vec![pollfd {
             fd: socket.as_raw_fd(),
@@ -70,7 +70,7 @@ mod poll {
                 return Err(io::Error::last_os_error());
             }
 
-            let event = match socket.next() {
+            let event = match socket.iter().next() {
                 Some(evt) => evt,
                 None => {
                     thread::sleep(Duration::from_millis(10));
@@ -107,7 +107,7 @@ mod poll {
 
             for event in &events {
                 if event.token() == Token(0) && event.readiness().is_writable() {
-                    socket.clone().for_each(|x| super::print_event(x));
+                    socket.iter().for_each(|x| super::print_event(x));
                 }
             }
         }
@@ -147,7 +147,7 @@ mod poll {
 
             for event in &events {
                 if event.token() == Token(0) && event.is_writable() {
-                    socket.clone().for_each(|x| super::print_event(x));
+                    socket.iter().for_each(|x| super::print_event(x));
                 }
             }
         }


### PR DESCRIPTION
This is a breaking patch that removes clone support for the Socket. Clone is removed becuase it gives the user the assumption that cloning the socket would allow user to receive multiple socket events from a single udev monitor (aka single producer, multi consumer). However, the udev monitor is a single producer, single consumer, and so cloning the socket would have unexpected behavior.

Now, in order to iterate over socket events, you have the SocketIter type, which implements Iterator and is internally a clone of the underlying udev monitor. This clone is better here, because it is part of the private API, and does not require caller to clone the socket when iterating.

Signed-off-by: thomas <thomas.chiantia@gmail.com>