### PR TITLE
Export SocketIter and remove SocketIter cloneing

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,10 @@ pub use enumerator::{Devices, Enumerator};
 #[cfg(feature = "hwdb")]
 pub use hwdb::Hwdb;
 pub use list::{Entry, List};
-pub use monitor::{Builder as MonitorBuilder, Event, EventType, Socket as MonitorSocket};
+pub use monitor::{
+    Builder as MonitorBuilder, Event, EventType, Socket as MonitorSocket,
+    SocketIter as MonitorSocketIter,
+};
 pub use udev::Udev;
 
 macro_rules! try_alloc {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -139,7 +139,7 @@ pub struct Socket {
 impl Socket {
     /// Create an iterator of socket event messages
     pub fn iter(&self) -> SocketIter {
-        SocketIter::new(self)
+        SocketIter::new(&self)
     }
 }
 
@@ -161,37 +161,28 @@ impl AsRawFd for Socket {
     }
 }
 
-pub struct SocketIter {
-    udev: Udev,
-    monitor: *mut ffi::udev_monitor,
+/// Iterator of socket events
+pub struct SocketIter<'a> {
+    socket: &'a Socket,
 }
 
-impl SocketIter {
+impl<'a> SocketIter<'a> {
     /// Create a socket by cloning the underlying udev instance
-    fn new(socket: &Socket) -> SocketIter {
-        SocketIter {
-            udev: socket.inner.udev.clone(),
-            monitor: unsafe { ffi::udev_monitor_ref(socket.inner.monitor) },
-        }
+    fn new(socket: &'a Socket) -> SocketIter<'a> {
+        SocketIter { socket }
     }
 }
 
-impl Drop for SocketIter {
-    fn drop(&mut self) {
-        unsafe { ffi::udev_monitor_unref(self.monitor) };
-    }
-}
-
-impl Iterator for SocketIter {
+impl<'a> Iterator for SocketIter<'a> {
     type Item = Event;
 
     fn next(&mut self) -> Option<Event> {
-        let ptr = unsafe { ffi::udev_monitor_receive_device(self.monitor) };
+        let ptr = unsafe { ffi::udev_monitor_receive_device(self.socket.inner.monitor) };
 
         if ptr.is_null() {
             None
         } else {
-            let device = Device::from_raw(self.udev.clone(), ptr);
+            let device = Device::from_raw(self.socket.inner.udev.clone(), ptr);
             Some(Event { device })
         }
     }


### PR DESCRIPTION
This is another fix that removes the clone entirely for the SocketIter type...

It holds a reference to the underlying monitor (instead of cloning).  This is similar to the `std::iter::Iter<'_,_>` type...

Also, when using the library I found I wanted the SocketIter type, but it was private. So I made it to export. This way you can create a custom iter that maps off the SocketIter (and you can't do that if the SocketIter is private)

Signed-off-by: thomas <thomas.chiantia@gmail.com>