### PR TITLE
Fix ARM compilation breakage, introduce DeviceType enum, and document.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -364,7 +364,7 @@ impl Device {
         }
     }
 
-    /// Returns the devtype name of the device.
+    /// Returns the devtype name of the device (if any), for example "disk".
     pub fn devtype(&self) -> Option<&OsStr> {
         unsafe { util::ptr_to_os_str(ffi::udev_device_get_devtype(self.device)) }
     }

--- a/src/device.rs
+++ b/src/device.rs
@@ -120,7 +120,7 @@ impl Device {
     /// or [`devnum`][Self::devnum]
     pub fn from_devnum_with_context(udev: Udev, dev_type: u8, devnum: dev_t) -> Result<Self> {
         let ptr = try_alloc!(unsafe {
-            ffi::udev_device_new_from_devnum(udev.as_raw(), dev_type as i8, devnum)
+            ffi::udev_device_new_from_devnum(udev.as_raw(), dev_type as c_char, devnum)
         });
 
         Ok(Self::from_raw(udev, ptr))

--- a/src/device.rs
+++ b/src/device.rs
@@ -21,6 +21,17 @@ pub struct Device {
     device: *mut ffi::udev_device,
 }
 
+/// Permissible types of UNIX file I/O API device special file.
+///
+/// See also [`from_devnum`][crate::Device::from_devnum].
+#[repr(u8)]
+pub enum DeviceType {
+    /// UNIX character-style file IO semantics.
+    Character = b'c',
+    /// UNIX block-style file IO semantics.
+    Block = b'b',
+}
+
 impl std::fmt::Debug for Device {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Device")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,7 +14,7 @@ extern crate mio07;
 #[cfg(feature = "mio08")]
 extern crate mio08;
 
-pub use device::{Attributes, Device, Properties};
+pub use device::{Attributes, Device, DeviceType, Properties};
 pub use enumerator::{Devices, Enumerator};
 #[cfg(feature = "hwdb")]
 pub use hwdb::Hwdb;


### PR DESCRIPTION
DRAFT PR for improving usability and documentation for the `Device::from_devnum` associated functions.

See #42 for background.