### PR TITLE
Replace `io-lifetimes` crate with libstd types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ keywords = ["udev", "hardware", "bindings", "sysfs"]
 readme = "README.md"
 
 [dependencies]
-io-lifetimes = "1.0.3"
 libudev-sys = "0.1.4"
 libc = "0.2"
 mio06 = { package = "mio", version = "^0.6.21", optional = true }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 #![warn(missing_docs)]
 
-extern crate io_lifetimes;
 extern crate libc;
 pub extern crate libudev_sys as ffi;
 #[cfg(feature = "mio06")]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::ptr;
 
 use std::ffi::OsStr;
@@ -6,7 +7,6 @@ use std::io::Result;
 use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, RawFd};
 
-use io_lifetimes::{AsFd, BorrowedFd};
 #[cfg(feature = "mio06")]
 use mio06::{event::Evented, unix::EventedFd, Poll, PollOpt, Ready, Token};
 #[cfg(feature = "mio07")]


### PR DESCRIPTION
These have been stable since Rust 1.63.0, so there shouldn't be a need to incur this dependency anymore