### PR TITLE
Make mio pub

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,13 +8,13 @@ extern crate io_lifetimes;
 extern crate libc;
 pub extern crate libudev_sys as ffi;
 #[cfg(feature = "mio06")]
-extern crate mio06;
+pub extern crate mio06;
 #[cfg(feature = "mio07")]
-extern crate mio07;
+pub extern crate mio07 as mio;
 #[cfg(feature = "mio08")]
-extern crate mio08;
+pub extern crate mio08 as mio;
 #[cfg(feature = "mio10")]
-extern crate mio10;
+pub extern crate mio10 as mio;
 
 pub use device::{Attributes, Device, DeviceType, Properties};
 pub use enumerator::{Devices, Enumerator};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ extern crate io_lifetimes;
 extern crate libc;
 pub extern crate libudev_sys as ffi;
 #[cfg(feature = "mio06")]
-pub extern crate mio06;
+pub extern crate mio06 as mio;
 #[cfg(feature = "mio07")]
 pub extern crate mio07 as mio;
 #[cfg(feature = "mio08")]

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -8,7 +8,7 @@ use std::os::unix::io::{AsRawFd, RawFd};
 
 use io_lifetimes::{AsFd, BorrowedFd};
 #[cfg(feature = "mio06")]
-use mio06::{event::Evented, unix::EventedFd, Poll, PollOpt, Ready, Token};
+use mio::{event::Evented, unix::EventedFd, Poll, PollOpt, Ready, Token};
 #[cfg(any(feature = "mio07", feature = "mio08", feature = "mio10"))]
 use mio::{event::Source, unix::SourceFd, Interest, Registry, Token};
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -9,12 +9,8 @@ use std::os::unix::io::{AsRawFd, RawFd};
 use io_lifetimes::{AsFd, BorrowedFd};
 #[cfg(feature = "mio06")]
 use mio06::{event::Evented, unix::EventedFd, Poll, PollOpt, Ready, Token};
-#[cfg(feature = "mio07")]
-use mio07::{event::Source, unix::SourceFd, Interest, Registry, Token};
-#[cfg(feature = "mio08")]
-use mio08::{event::Source, unix::SourceFd, Interest, Registry, Token};
-#[cfg(feature = "mio10")]
-use mio10::{event::Source, unix::SourceFd, Interest, Registry, Token};
+#[cfg(any(feature = "mio07", feature = "mio08", feature = "mio10"))]
+use mio::{event::Source, unix::SourceFd, Interest, Registry, Token};
 
 use Udev;
 use {ffi, util};


### PR DESCRIPTION
That allows to refer to the exact version used by the library in our lib/app without having to include mio in our dependencies.