### PR TITLE
Add `send` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ pkg-config = "0.3.3" #force a newer version for libudev-sys to fix minimal versi
 [features]
 mio = ["mio10"] # mio feature defaults to the newest mio version
 hwdb = []
+send = []

--- a/src/device.rs
+++ b/src/device.rs
@@ -68,6 +68,9 @@ impl Drop for Device {
     }
 }
 
+#[cfg(feature = "send")]
+unsafe impl Send for Device {}
+
 as_ffi_with_context!(Device, device, ffi::udev_device, ffi::udev_device_ref);
 
 /// A convenience alias for a list of properties, bound to a device.

--- a/src/enumerator.rs
+++ b/src/enumerator.rs
@@ -33,6 +33,9 @@ impl Drop for Enumerator {
     }
 }
 
+#[cfg(feature = "send")]
+unsafe impl Send for Enumerator {}
+
 as_ffi_with_context!(
     Enumerator,
     enumerator,

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -30,6 +30,9 @@ impl Drop for Hwdb {
     }
 }
 
+#[cfg(feature = "send")]
+unsafe impl Send for Hwdb {}
+
 as_ffi!(Hwdb, hwdb, ffi::udev_hwdb, ffi::udev_hwdb_ref);
 
 impl Hwdb {

--- a/src/list.rs
+++ b/src/list.rs
@@ -14,6 +14,10 @@ pub struct List<'a, T: 'a, E: 'a> {
     pub(crate) entry: *mut ffi::udev_list_entry,
     pub(crate) phantom: PhantomData<&'a (T, E)>,
 }
+
+#[cfg(feature = "send")]
+unsafe impl<T, E> Send for List<'_, T, E> {}
+
 pub type EntryList<'a, T> = List<'a, T, Entry<'a>>;
 
 impl<'a, T> Iterator for EntryList<'a, T> {

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -48,6 +48,9 @@ impl Drop for Builder {
     }
 }
 
+#[cfg(feature = "send")]
+unsafe impl Send for Builder {}
+
 as_ffi_with_context!(Builder, monitor, ffi::udev_monitor, ffi::udev_monitor_ref);
 
 /// The event source to monitor.

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -31,6 +31,9 @@ impl Drop for Udev {
     }
 }
 
+#[cfg(feature = "send")]
+unsafe impl Send for Udev {}
+
 as_ffi!(Udev, udev, ffi::udev, ffi::udev_ref);
 
 impl Udev {


### PR DESCRIPTION
Since most udev libraries should be safe to access across threads, this flag allows a consumer to opt in to allowing cross-thread access. However, since this isn't necessarily guaranteed, it's not enabled by default.

Fix for #29