### PR TITLE
Add `sync` feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,4 @@ pkg-config = "0.3.3" #force a newer version for libudev-sys to fix minimal versi
 mio = ["mio10"] # mio feature defaults to the newest mio version
 hwdb = []
 send = []
+sync = []

--- a/src/device.rs
+++ b/src/device.rs
@@ -70,6 +70,8 @@ impl Drop for Device {
 
 #[cfg(feature = "send")]
 unsafe impl Send for Device {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Device {}
 
 as_ffi_with_context!(Device, device, ffi::udev_device, ffi::udev_device_ref);
 

--- a/src/enumerator.rs
+++ b/src/enumerator.rs
@@ -35,6 +35,8 @@ impl Drop for Enumerator {
 
 #[cfg(feature = "send")]
 unsafe impl Send for Enumerator {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Enumerator {}
 
 as_ffi_with_context!(
     Enumerator,

--- a/src/hwdb.rs
+++ b/src/hwdb.rs
@@ -32,6 +32,8 @@ impl Drop for Hwdb {
 
 #[cfg(feature = "send")]
 unsafe impl Send for Hwdb {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Hwdb {}
 
 as_ffi!(Hwdb, hwdb, ffi::udev_hwdb, ffi::udev_hwdb_ref);
 

--- a/src/list.rs
+++ b/src/list.rs
@@ -17,6 +17,8 @@ pub struct List<'a, T: 'a, E: 'a> {
 
 #[cfg(feature = "send")]
 unsafe impl<T, E> Send for List<'_, T, E> {}
+#[cfg(feature = "sync")]
+unsafe impl<T, E> Sync for List<'_, T, E> {}
 
 pub type EntryList<'a, T> = List<'a, T, Entry<'a>>;
 

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -50,6 +50,8 @@ impl Drop for Builder {
 
 #[cfg(feature = "send")]
 unsafe impl Send for Builder {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Builder {}
 
 as_ffi_with_context!(Builder, monitor, ffi::udev_monitor, ffi::udev_monitor_ref);
 

--- a/src/udev.rs
+++ b/src/udev.rs
@@ -33,6 +33,8 @@ impl Drop for Udev {
 
 #[cfg(feature = "send")]
 unsafe impl Send for Udev {}
+#[cfg(feature = "sync")]
+unsafe impl Sync for Udev {}
 
 as_ffi!(Udev, udev, ffi::udev, ffi::udev_ref);
 


### PR DESCRIPTION
Much like the `send` feature flag, the `sync` feature flag enables the Sync trait on all relevant types to allow full cross-thread access, depending on the safety of the underlying udev library.

Followup to #55. I probably should have filed this at the same time. I'm not sure if these should be separate feature flags, but you already tagged 0.9.2 with `send` so that's in a stable build now.